### PR TITLE
Auto-open sidebar on mobile for better navigation

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/components/layouts/main-layout.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/layouts/main-layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ReactNode, useState } from 'react'
+import { ReactNode, useState, useEffect } from 'react'
 import Sidebar from './sidebar/sidebar'
 import { Menu, ArrowUp } from 'lucide-react'
 import { SITE } from "@/lib/constants"
@@ -12,12 +12,22 @@ interface MainLayoutProps {
 
 export function MainLayout({ children, onGameSelect }: MainLayoutProps) {
     const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+    const [hasMounted, setHasMounted] = useState(false)
 
     // Add handler to close sidebar
     const handleOverlayClick = (e: React.MouseEvent) => {
         e.preventDefault()
         setIsSidebarOpen(false)
     }
+
+    // Auto-open sidebar on mobile devices on first load
+    useEffect(() => {
+        if (!hasMounted) {
+            const isMobile = window.innerWidth < 1024 // 1024px matches our lg breakpoint
+            setIsSidebarOpen(isMobile)
+            setHasMounted(true)
+        }
+    }, [hasMounted])
 
     return (
         <div className="flex h-[100dvh] relative">


### PR DESCRIPTION
This enhancement automatically opens the sidebar navigation when users first visit the site on mobile devices, improving discoverability and initial user experience.

## Changes
- Added mobile device detection using window width (1024px breakpoint)
- Implemented auto-open behavior specifically for mobile users
- Added state management to ensure the behavior only triggers on initial page load
- Preserved all existing sidebar functionality for both mobile and desktop users

## Technical Details
- Uses `window.innerWidth` for mobile detection
- Matches existing Tailwind `lg` breakpoint (1024px)
- Implements `hasMounted` state to prevent unnecessary re-renders
- Maintains existing overlay and animation behavior

## Testing
- Verified auto-open behavior on mobile devices (width < 1024px)
- Confirmed desktop experience remains unchanged
- Tested manual sidebar controls (open/close) continue to work as expected
- Verified sidebar state persists appropriately after initial load
- Tested overlay click-to-close functionality

This change enhances the mobile user experience by making the game selection interface immediately visible to users on smaller devices, reducing the number of required interactions to start using the application.