### PR TITLE
ci: add version bump workflow for main branch merges

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -1,0 +1,51 @@
+name: Main Branch Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Determine Version Bump Type
+        id: bump-type
+        run: |
+          # Get the commit message
+          COMMIT_MSG=$(git log --format=%B -n 1)
+          
+          if [[ $COMMIT_MSG =~ ^feat!: ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ $COMMIT_MSG =~ ^feat: ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Bump Version
+        run: |
+          BUMP_TYPE=${{ steps.bump-type.outputs.type }}
+          npm version $BUMP_TYPE --no-git-tag-version
+          
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          cd apps/sploosh-ai-hockey-analytics
+          npm version $NEW_VERSION --no-git-tag-version
+          
+      - name: Commit Version Bump
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "chore: bump version [skip ci]"
+          git push
+
+permissions:
+  contents: write 


### PR DESCRIPTION
## Description
Adding workflow to automatically bump versions when PRs are merged to main.

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] I have tested these changes locally using `act`