### PR TITLE
ci: fix version bump workflow by adding dependency installation

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -22,10 +22,16 @@ jobs:
         with:
           node-version: '20'
           
+      - name: Install Dependencies
+        run: |
+          npm install
+          cd apps/sploosh-ai-hockey-analytics
+          npm install
+          cd ../..
+          
       - name: Determine Version Bump Type
         id: bump-type
         run: |
-          # Get the commit message
           COMMIT_MSG=$(git log --format=%B -n 1)
           
           if [[ $COMMIT_MSG =~ ^feat!: ]]; then


### PR DESCRIPTION
## Description
Fixes the version bump workflow by:
- Adding npm install steps for both root and app directories
- Ensuring correct directory navigation
- Maintaining proper git configuration

This should resolve the issue where version numbers weren't being updated after merges to main.

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass

## Expected Behavior
After merging:
1. Workflow will properly install dependencies
2. Create a new PR with version bumps
3. Update both package.json files when merged