### PR TITLE
ci: add debugging to version bump workflow

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Determine Version Bump Type
         id: bump-type
         run: |
+          echo "Last commit message:"
+          git log --format=%B -n 1
+          
           COMMIT_MSG=$(git log --format=%B -n 1)
+          echo "Commit message: $COMMIT_MSG"
           
           if [[ $COMMIT_MSG =~ ^feat!: ]]; then
             echo "type=major" >> $GITHUB_OUTPUT
@@ -41,6 +45,8 @@ jobs:
           else
             echo "type=patch" >> $GITHUB_OUTPUT
           fi
+          
+          echo "Determined bump type: $(cat $GITHUB_OUTPUT)"
       
       - name: Create Version Bump Branch
         run: |


### PR DESCRIPTION
## Description
Adds debug logging to the version bump workflow to help diagnose why automated version PRs aren't being created. Changes include:
- Log the last commit message
- Show the detected version bump type
- Display GitHub output variables

This will help us understand:
- If commit messages are being read correctly
- If version bump type is being determined properly
- Where in the process the workflow might be failing

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] All existing tests pass