### PR TITLE
docs: add more version bump examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ This project uses semantic versioning. Version numbers are automatically updated
 - `feat:` - Minor version bump (new features)
 - `fix:`, `docs:`, etc. - Patch version bump
 
+Example: 
+- A PR titled `feat: add new feature` will bump 0.1.0 → 0.2.0
+- A PR titled `docs: update readme` will bump 0.1.0 → 0.1.1
+
 ### Option 1: Local Development
 
 Install dependencies and start the development server:


### PR DESCRIPTION
## Description
Adding another example of version bumping to make the documentation even clearer. This adds:
- Example of a patch version bump with docs changes
- More concrete version number examples
- Clearer explanation of the versioning process

## Type of Change
version: docs     # Documentation changes

## Testing
- [x] All existing tests pass