### PR TITLE
ci: fix git identity for version bump commits

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Create Version Bump Branch
         id: create_branch
         run: |
+          # Configure git
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
           # Create new branch
           BRANCH_NAME="version-bump-${{ github.sha }}"
           git checkout -b $BRANCH_NAME


### PR DESCRIPTION
## Description
Fixes the git identity issue in the version bump workflow by:
- Adding git config at the start of the step
- Using GitHub Actions bot email and name
- Using global config to ensure it's set properly

This should resolve the issue where:
1. Git commits were failing due to unknown author
2. Version bump process was stopping early
3. PRs weren't being created due to commit failures

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] All existing tests pass