### PR TITLE
ci: ensure only package.json files are modified

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -54,9 +54,6 @@ jobs:
           pwd
           ls -la
           
-          echo "Current package.json version:"
-          cat package.json | grep version
-          
           # Create new branch
           BRANCH_NAME="version-bump-${{ github.sha }}"
           git checkout -b $BRANCH_NAME
@@ -65,18 +62,21 @@ jobs:
           OLD_VERSION=$(node -p "require('./package.json').version")
           echo "Old version: $OLD_VERSION"
           
-          # Bump versions
+          # Determine new version
           BUMP_TYPE=${{ steps.bump-type.outputs.type }}
           echo "Bump type: $BUMP_TYPE"
           
-          # Update root package.json
-          npm version $BUMP_TYPE --no-git-tag-version
-          NEW_VERSION=$(node -p "require('./package.json').version")
+          # Use npm version to calculate new version number only
+          NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version)
+          # Reset the change npm version made
+          git checkout package.json package-lock.json
+          
           echo "New version: $NEW_VERSION"
           
-          # Update app package.json
+          # Manually update package.json files
+          jq ".version = \"${NEW_VERSION#v}\"" package.json > temp.json && mv temp.json package.json
           cd apps/sploosh-ai-hockey-analytics
-          npm version $NEW_VERSION --no-git-tag-version
+          jq ".version = \"${NEW_VERSION#v}\"" package.json > temp.json && mv temp.json package.json
           cd ../..
           
           echo "Updated package.json versions:"
@@ -85,12 +85,12 @@ jobs:
           
           # Stage only package.json files
           git add package.json apps/sploosh-ai-hockey-analytics/package.json
-          git commit -m "chore: bump version from ${OLD_VERSION} to ${NEW_VERSION}"
+          git commit -m "chore: bump version from ${OLD_VERSION} to ${NEW_VERSION#v}"
           
           # Force push branch
           git push -f origin $BRANCH_NAME
           
-          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "new_version=${NEW_VERSION#v}" >> $GITHUB_OUTPUT
           echo "old_version=${OLD_VERSION}" >> $GITHUB_OUTPUT
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
       


### PR DESCRIPTION
## Description
Fixes the version bump workflow to strictly modify only package.json files:
- Uses npm version only for version calculation
- Resets any npm version file changes
- Uses jq to update package.json files directly
- Never modifies package-lock.json files
- Improves version update precision

This should resolve the issue where:
1. Package-lock.json files were being included in PRs
2. Version updates weren't isolated to package.json
3. npm version was modifying too many files

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] All existing tests pass