### PR TITLE
ci: fix package-lock.json file check

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -68,8 +68,9 @@ jobs:
           
           # Use npm version to calculate new version number only
           NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version)
-          # Reset the change npm version made
-          git checkout package.json package-lock.json
+          # Reset the change npm version made (only if file exists)
+          git checkout package.json
+          [ -f package-lock.json ] && git checkout package-lock.json
           
           echo "New version: $NEW_VERSION"
           


### PR DESCRIPTION
## Description
Fixes the version bump workflow to handle missing package-lock.json:
- Adds existence check for package-lock.json
- Separates package.json and package-lock.json resets
- Makes file handling more robust
- Maintains all other version bump functionality

This should resolve the issue where:
1. Workflow fails when package-lock.json doesn't exist
2. Git checkout fails on missing files
3. Process stops before version update

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] All existing tests pass