### PR TITLE
ci: use git reset instead of checkout

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -68,8 +68,8 @@ jobs:
           
           # Use npm version to calculate new version number only
           NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version)
-          # Reset the change npm version made
-          git checkout package.json package-lock.json
+          # Reset any changes npm version made
+          git reset --hard HEAD
           
           echo "New version: $NEW_VERSION"
           


### PR DESCRIPTION
## Description
Fixes the version bump workflow file handling:
- Uses git reset --hard instead of checkout
- Removes specific file handling
- Simplifies the reset process
- Makes version calculation more reliable

This should resolve the issue where:
1. Git checkout fails on missing files
2. Package-lock.json causes errors
3. Version updates fail to complete

## Type of Change
version: ci      # CI/CD changes

## Testing
- [x] All existing tests pass