### PR TITLE
fix: resolve version bump workflow parsing error

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -58,8 +58,9 @@ jobs:
           BUMP_TYPE=${{ steps.bump-type.outputs.type }}
           echo "Bump type: $BUMP_TYPE"
           
-          # Calculate new version without modifying files
-          NEW_VERSION=$(npm --no-git-tag-version version $BUMP_TYPE --json | jq -r '."sploosh-ai-hockey-analytics"')
+          # Calculate new version using npm semver capabilities
+          NEW_VERSION=$(npm --no-git-tag-version version $BUMP_TYPE)
+          NEW_VERSION=${NEW_VERSION:1} # Remove the 'v' prefix
           
           # Reset any changes npm version made
           git checkout package.json package-lock.json


### PR DESCRIPTION
## Description
The version bump workflow was failing when trying to parse the npm version command output as JSON. This PR fixes the issue by:
- Removing the --json flag from npm version command
- Directly manipulating the version string output
- Maintaining proper version synchronization between package.json files

## Type of Change
version: fix

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass