### PR TITLE
fix: remove package-lock.json check from version bump

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -62,8 +62,8 @@ jobs:
           NEW_VERSION=$(npm --no-git-tag-version version $BUMP_TYPE)
           NEW_VERSION=${NEW_VERSION:1} # Remove the 'v' prefix
           
-          # Reset any changes npm version made
-          git checkout package.json package-lock.json
+          # Reset package.json (no need to reset package-lock.json)
+          git checkout package.json
           
           # Update root package.json
           jq ".version = \"$NEW_VERSION\"" package.json > temp.json && mv temp.json package.json


### PR DESCRIPTION
## Description
The version bump workflow was failing when trying to reset package-lock.json, which doesn't exist in our repository. This PR fixes the issue by:
- Removing the package-lock.json reset step
- Keeping only the necessary package.json reset
- Maintaining proper version synchronization between package.json files

## Type of Change
version: fix

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass