### PR TITLE
fix: add repository checkout to merge job

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -135,6 +135,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
       - name: Wait for checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
The merge job was failing because it couldn't access git information. This PR fixes the issue by:
- Adding repository checkout to the merge job
- Ensuring git commands can run properly
- Maintaining all existing check status monitoring
- Preserving automatic merge functionality

## Type of Change
version: fix

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass