### PR TITLE
fix: add status check permissions to merge job

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -134,6 +134,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: read
+      statuses: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -149,12 +151,12 @@ jobs:
           timeout=600
           while [ $timeout -gt 0 ]; do
             # Get check status using correct fields
-            STATUSES=$(gh pr checks ${{ needs.version-bump.outputs.pr_number }} --json state,name -q '.[] | "\(.name):\(.state)"')
+            STATUSES=$(gh pr view ${{ needs.version-bump.outputs.pr_number }} --json statusCheckRollup --jq '.statusCheckRollup.[].state')
             echo "Current check statuses:"
             echo "$STATUSES"
             
             # Check if any are still pending
-            if echo "$STATUSES" | grep -q "pending\|in_progress\|queued"; then
+            if echo "$STATUSES" | grep -q "PENDING"; then
               echo "Checks still running... ($timeout seconds remaining)"
               sleep 10
               timeout=$((timeout - 10))
@@ -162,7 +164,7 @@ jobs:
             fi
             
             # Check if any failed
-            if echo "$STATUSES" | grep -q "failure"; then
+            if echo "$STATUSES" | grep -q "FAILURE"; then
               echo "Some checks failed!"
               exit 1
             fi


### PR DESCRIPTION
## Description
The merge job was failing due to insufficient permissions to check PR status. This PR fixes the issue by:
- Adding necessary permissions for status checks
- Updating the status check query to use PR view
- Using the correct GraphQL fields for status checks
- Maintaining automatic merge functionality

## Type of Change
version: fix

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass