### PR TITLE
fix: correct version bump type detection and expand tests

### DIFF
--- a/.github/test-pr-event-major.json
+++ b/.github/test-pr-event-major.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "feat!: redesign authentication system",
+        "body": "BREAKING CHANGE: Complete overhaul of auth system",
+        "number": 1,
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics/pull/1"
+    },
+    "repository": {
+        "full_name": "SplooshAI/sploosh-ai-hockey-analytics",
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics"
+    }
+}

--- a/.github/test-pr-event-minor.json
+++ b/.github/test-pr-event-minor.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "feat: add shot chart visualization",
+        "body": "Adding new feature for shot visualization",
+        "number": 2,
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics/pull/2"
+    },
+    "repository": {
+        "full_name": "SplooshAI/sploosh-ai-hockey-analytics",
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics"
+    }
+}

--- a/.github/test-pr-event-patch.json
+++ b/.github/test-pr-event-patch.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "fix: correct stats calculation",
+        "body": "Fixed bug in statistics calculation",
+        "number": 3,
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics/pull/3"
+    },
+    "repository": {
+        "full_name": "SplooshAI/sploosh-ai-hockey-analytics",
+        "html_url": "https://github.com/SplooshAI/sploosh-ai-hockey-analytics"
+    }
+}

--- a/.github/test-workflows.sh
+++ b/.github/test-workflows.sh
@@ -6,17 +6,28 @@ echo ""
 echo "📋 Testing Semantic PR Check workflow..."
 echo ""
 
-echo "1. Testing valid PR..."
-act pull_request -e .github/test-pr-event.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
+echo "1. Testing major version bump (breaking change)..."
+act pull_request -e .github/test-pr-event-major.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
 echo ""
 
-echo "2. Testing invalid PR..."
+echo "2. Testing minor version bump (new feature)..."
+act pull_request -e .github/test-pr-event-minor.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
+echo ""
+
+echo "3. Testing patch version bump (fix)..."
+act pull_request -e .github/test-pr-event-patch.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
+echo ""
+
+echo "4. Testing invalid PR format..."
 act pull_request -e .github/test-pr-event-invalid.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
 echo ""
 
-echo "3. Testing breaking change PR..."
-act pull_request -e .github/test-pr-event-breaking.json -W .github/workflows/semantic-pr-check.yml --container-architecture linux/amd64
+echo "🔄 Testing Version Bump workflow..."
 echo ""
 
-echo "🔄 Testing Version Bump workflow..."
-act workflow_dispatch -W .github/workflows/version-bump.yml --container-architecture linux/amd64 
+echo "Testing version bump types..."
+for type in major minor patch; do
+  echo "Testing $type version bump..."
+  act workflow_dispatch -W .github/workflows/version-bump.yml --container-architecture linux/amd64 -e .github/test-pr-event-$type.json
+  echo ""
+done 

--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -33,12 +33,24 @@ jobs:
           COMMIT_MSG=$(git log --format=%B -n 1)
           echo "Commit message: $COMMIT_MSG"
           
+          # Major version bump for breaking changes
           if [[ $COMMIT_MSG =~ ^feat!: ]]; then
             echo "type=major" >> $GITHUB_OUTPUT
+            echo "Major version bump triggered by breaking change"
+          
+          # Minor version bump for new features
           elif [[ $COMMIT_MSG =~ ^feat: ]]; then
             echo "type=minor" >> $GITHUB_OUTPUT
-          else
+            echo "Minor version bump triggered by new feature"
+          
+          # Patch version bump for all other types
+          elif [[ $COMMIT_MSG =~ ^(fix|docs|style|refactor|perf|test|build|ci|chore|revert): ]]; then
             echo "type=patch" >> $GITHUB_OUTPUT
+            echo "Patch version bump triggered by maintenance change"
+          
+          else
+            echo "❌ Invalid commit message format"
+            exit 1
           fi
       
       - name: Create Version Bump Branch

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "docker:nhl:dev:build": "GIT_HASH=$(git rev-parse HEAD) GIT_DATE=$(git log -1 --format=%aI) docker compose -f docker/sploosh-ai-hockey-analytics/development/docker-compose.yml -p sploosh-ai-hockey-analytics-dev up --build",
     "docker:nhl:dev:down": "docker compose -f docker/sploosh-ai-hockey-analytics/development/docker-compose.yml -p sploosh-ai-hockey-analytics-dev down -v",
     "test:workflows": "chmod +x .github/test-workflows.sh && .github/test-workflows.sh",
-    "test:workflows:semantic": "act pull_request -e .github/test-pr-event.json -W .github/workflows/semantic-pr-check.yml",
+    "test:workflows:semantic": "act pull_request -e .github/test-pr-event-minor.json -W .github/workflows/semantic-pr-check.yml",
+    "test:workflows:semantic:major": "act pull_request -e .github/test-pr-event-major.json -W .github/workflows/semantic-pr-check.yml",
+    "test:workflows:semantic:minor": "act pull_request -e .github/test-pr-event-minor.json -W .github/workflows/semantic-pr-check.yml",
+    "test:workflows:semantic:patch": "act pull_request -e .github/test-pr-event-patch.json -W .github/workflows/semantic-pr-check.yml",
+    "test:workflows:semantic:invalid": "act pull_request -e .github/test-pr-event-invalid.json -W .github/workflows/semantic-pr-check.yml",
     "test:workflows:version": "act workflow_dispatch -W .github/workflows/version-bump.yml --container-architecture linux/amd64"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes a critical bug where PR title prefixes weren't being properly mapped to version bump types. Previously only `feat!:` and `feat:` were being checked, with everything else defaulting to patch. Now properly detects all semantic prefixes as defined in CONTRIBUTING.md.

Changes:
- Fix version bump type detection in main-merge.yml to check all semantic prefixes:
  - `feat!:` → major version bump
  - `feat:` → minor version bump
  - `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, `chore:`, `revert:` → patch version bump
- Add comprehensive test cases:
  - test-pr-event-major.json for breaking changes
  - test-pr-event-minor.json for new features
  - test-pr-event-patch.json for fixes
- Expand test workflow script to cover all version bump scenarios
- Add individual npm scripts for testing specific version bump types

Testing:
- [x] Tested major version bump with `feat!:` prefix
- [x] Tested minor version bump with `feat:` prefix
- [x] Tested patch version bump with other prefixes
- [x] Verified invalid formats are rejected
- [x] All existing tests pass

Type of Change:
version: fix      # Bug fix (patch version bump)