### PR TITLE
fix: lock Next.js version to exact 15.1.6

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/package.json
+++ b/apps/sploosh-ai-hockey-analytics/package.json
@@ -16,7 +16,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.468.0",
-    "next": "^15.1.6",
+    "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "tailwind-merge": "^2.5.5",


### PR DESCRIPTION
## Description
Changes Next.js dependency from `^15.1.6` to `15.1.6` to ensure consistent behavior across all environments and prevent unexpected updates.

## Type of Change
version: fix      # Bug fix (patch version bump)

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass

## Impact
This change:
- Locks Next.js to exact version 15.1.6
- Prevents automatic patch version updates
- Ensures consistent framework behavior
- Reduces risk of unexpected breaking changes