### PR TITLE
fix: disable caching for NHL API requests to ensure live game data updates

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/lib/api/nhl-edge/server/client.ts
+++ b/apps/sploosh-ai-hockey-analytics/lib/api/nhl-edge/server/client.ts
@@ -24,6 +24,8 @@ export async function fetchNHLEdge<T>(endpoint: string, init?: RequestInit): Pro
             'Accept': 'application/json',
             ...init?.headers,
         },
+        cache: 'no-store', // Disable caching for live game data
+        next: { revalidate: 0 }, // Ensure Next.js doesn't cache
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Description

Fixed an issue where the scoreboard was displaying stale game data due to Next.js 15's aggressive caching. The Colorado vs LA Kings game was showing "2nd INT - 00:00" when it was actually in the 3rd period.

The fix disables caching for all NHL Edge API requests by adding:
- `cache: 'no-store'` - Disables fetch-level caching
- `next: { revalidate: 0 }` - Ensures Next.js doesn't cache responses

This ensures live game data updates properly with the 20-second auto-refresh in the sidebar.

## Type of Change
version: fix

## Testing
- [x] Verified Docker development environment starts correctly
- [x] Confirmed API requests are no longer cached
- [x] Live game data now updates properly on auto-refresh