### PR TITLE
feat: make 3D Arena the default view and improve mobile UX

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/app/page.tsx
+++ b/apps/sploosh-ai-hockey-analytics/app/page.tsx
@@ -26,7 +26,7 @@ function HomeContent() {
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null)
   const [isUsingCachedData, setIsUsingCachedData] = useState(false)
   const [cachedLogoUrl, setCachedLogoUrl] = useState<string>('/sploosh.ai/sploosh-ai-character-transparent.png')
-  const [shotChartView, setShotChartView] = useState<'2d' | '3d'>('2d')
+  const [shotChartView, setShotChartView] = useState<'2d' | '3d'>('3d')
   const isSelectingGameRef = useRef(false)
   const selectedGameIdRef = useRef<number | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
@@ -335,11 +335,6 @@ function HomeContent() {
                       <span className="ml-1.5 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400">New</span>
                     </button>
                   </div>
-                  {shotChartView === '3d' && (
-                    <span className="text-xs text-muted-foreground">
-                      Inside Sploosh.AI Arena
-                    </span>
-                  )}
                 </div>
 
                 {shotChartView === '2d' ? (

--- a/apps/sploosh-ai-hockey-analytics/components/features/shot-chart-3d/shot-chart-3d.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/shot-chart-3d/shot-chart-3d.tsx
@@ -328,7 +328,7 @@ export const ShotChart3D: React.FC<ShotChart3DProps> = ({
                   style={{ backgroundColor: awayColor, transform: 'rotate(45deg)' }}
                   aria-hidden
                 />
-                {awayTeamName} (Away)
+                {awayTeamName}
               </span>
               <span className="flex items-center gap-1.5">
                 <span
@@ -336,25 +336,27 @@ export const ShotChart3D: React.FC<ShotChart3DProps> = ({
                   style={{ backgroundColor: homeColor }}
                   aria-hidden
                 />
-                {homeTeamName} (Home)
+                {homeTeamName}
               </span>
             </div>
 
-            <div className="flex flex-wrap gap-2 items-center text-sm">
+            <div className="space-y-2 text-sm">
               <label className="text-sm font-medium whitespace-nowrap">Camera:</label>
-              {(Object.keys(CAMERA_PRESETS) as CameraPreset[]).map((key) => (
-                <button
-                  key={key}
-                  onClick={() => setCameraPreset(key)}
-                  className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
-                    cameraPreset === key
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'border-border hover:bg-muted'
-                  }`}
-                >
-                  {CAMERA_PRESETS[key].label}
-                </button>
-              ))}
+              <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
+                {(Object.keys(CAMERA_PRESETS) as CameraPreset[]).map((key) => (
+                  <button
+                    key={key}
+                    onClick={() => setCameraPreset(key)}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
+                      cameraPreset === key
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'border-border hover:bg-muted'
+                    }`}
+                  >
+                    {CAMERA_PRESETS[key].label}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
# Pull Request

## Description

This PR makes the 3D Arena view the default experience for users and improves the mobile user interface:

- **Default View Change**: Changed the initial shot chart view from 2D Rink to 3D Arena, making the immersive 3D experience the first thing users see
- **Cleaner Interface**: Removed the 'Inside Sploosh.AI Arena' text that was appearing as disconnected UI element
- **Mobile Layout Improvements**: 
  - Improved camera button layout using responsive grid (2x2 on mobile, flexible wrap on desktop)
  - Removed '(Away)' and '(Home)' labels from team names for cleaner display
  - Better spacing and organization of controls

## Type of Change
version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally using the development server
- [x] Verified 3D Arena loads as default view
- [x] Tested responsive camera button layout on mobile and desktop
- [x] Confirmed cleaner team name display
- [x] All existing tests pass
- [x] My commits are signed with GPG