### PR TITLE
fix: handle postseason period labeling correctly (no shootouts, continuous OT)

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/app/page.tsx
+++ b/apps/sploosh-ai-hockey-analytics/app/page.tsx
@@ -339,12 +339,12 @@ function HomeContent() {
 
                 {shotChartView === '2d' ? (
                   <ShotChart
-                    gameData={playByPlayData}
+                    gameData={{...playByPlayData, ...gameCenterData}}
                     showCenterLogo={true}
                     centerIceLogo={cachedLogoUrl}
                   />
                 ) : (
-                  <ShotChart3D gameData={playByPlayData} centerIceLogo={cachedLogoUrl} />
+                  <ShotChart3D gameData={{...playByPlayData, ...gameCenterData}} centerIceLogo={cachedLogoUrl} />
                 )}
               </div>
 

--- a/apps/sploosh-ai-hockey-analytics/components/features/shot-chart-3d/shot-chart-3d.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/shot-chart-3d/shot-chart-3d.tsx
@@ -271,7 +271,7 @@ export const ShotChart3D: React.FC<ShotChart3DProps> = ({
                   <option value="">All Periods</option>
                   {periods.map((p) => (
                     <option key={p} value={p}>
-                      {formatPeriodLabel(p)}
+                      {formatPeriodLabel(p, gameData)}
                     </option>
                   ))}
                 </select>

--- a/apps/sploosh-ai-hockey-analytics/components/features/shot-chart/shot-chart.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/shot-chart/shot-chart.tsx
@@ -316,7 +316,7 @@ export const ShotChart: React.FC<ShotChartProps> = ({
                   <option value="">All Periods</option>
                   {periods.map(period => (
                     <option key={period} value={period}>
-                      {formatPeriodLabel(period)}
+                      {formatPeriodLabel(period, gameData)}
                     </option>
                   ))}
                 </select>

--- a/apps/sploosh-ai-hockey-analytics/lib/utils/formatters.postseason.test.ts
+++ b/apps/sploosh-ai-hockey-analytics/lib/utils/formatters.postseason.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Test postseason period formatting
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatPeriodLabel } from './formatters'
+
+describe('formatPeriodLabel - Postseason Handling', () => {
+  const regularSeasonGameData = { gameType: 2 }
+  const postseasonGameData = { gameType: 3 }
+
+  describe('Regular Season Games', () => {
+    it('should format regulation periods correctly', () => {
+      expect(formatPeriodLabel(1, regularSeasonGameData)).toBe('1st')
+      expect(formatPeriodLabel(2, regularSeasonGameData)).toBe('2nd')
+      expect(formatPeriodLabel(3, regularSeasonGameData)).toBe('3rd')
+    })
+
+    it('should format overtime as "OT"', () => {
+      expect(formatPeriodLabel(4, regularSeasonGameData)).toBe('OT')
+    })
+
+    it('should format period 5 as "SO" (shootout)', () => {
+      expect(formatPeriodLabel(5, regularSeasonGameData)).toBe('SO')
+    })
+
+    it('should handle multiple overtimes (rare case)', () => {
+      expect(formatPeriodLabel(6, regularSeasonGameData)).toBe('2OT')
+      expect(formatPeriodLabel(7, regularSeasonGameData)).toBe('3OT')
+    })
+  })
+
+  describe('Postseason Games', () => {
+    it('should format regulation periods correctly', () => {
+      expect(formatPeriodLabel(1, postseasonGameData)).toBe('1st')
+      expect(formatPeriodLabel(2, postseasonGameData)).toBe('2nd')
+      expect(formatPeriodLabel(3, postseasonGameData)).toBe('3rd')
+    })
+
+    it('should format overtime as "OT"', () => {
+      expect(formatPeriodLabel(4, postseasonGameData)).toBe('OT')
+    })
+
+    it('should format period 5 as "2OT" (no shootouts in playoffs)', () => {
+      expect(formatPeriodLabel(5, postseasonGameData)).toBe('2OT')
+    })
+
+    it('should format multiple overtimes correctly', () => {
+      expect(formatPeriodLabel(6, postseasonGameData)).toBe('3OT')
+      expect(formatPeriodLabel(7, postseasonGameData)).toBe('4OT')
+    })
+  })
+
+  describe('Backward Compatibility', () => {
+    it('should work without game data parameter', () => {
+      expect(formatPeriodLabel(1)).toBe('1st')
+      expect(formatPeriodLabel(4)).toBe('OT')
+      expect(formatPeriodLabel(5)).toBe('SO') // Defaults to regular season behavior
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle unexpected period numbers', () => {
+      expect(formatPeriodLabel(0, postseasonGameData)).toBe('Period 0')
+      expect(formatPeriodLabel(99, postseasonGameData)).toBe('Period 99')
+    })
+  })
+})

--- a/apps/sploosh-ai-hockey-analytics/lib/utils/formatters.ts
+++ b/apps/sploosh-ai-hockey-analytics/lib/utils/formatters.ts
@@ -36,6 +36,7 @@ export function formatTeamAbbrev(team: { abbrev: string }): string {
  * Format a period number to its display label
  * 
  * @param period - The period number (1-3 for regulation, 4+ for overtime/shootout)
+ * @param gameData - Optional game data to determine if postseason (no shootouts)
  * @returns The formatted period label
  * 
  * @example
@@ -43,9 +44,10 @@ export function formatTeamAbbrev(team: { abbrev: string }): string {
  * formatPeriodLabel(2) // "2nd"
  * formatPeriodLabel(3) // "3rd"
  * formatPeriodLabel(4) // "OT"
- * formatPeriodLabel(5) // "SO"
+ * formatPeriodLabel(5) // "SO" (regular season)
+ * formatPeriodLabel(5, postseasonGameData) // "2OT" (postseason)
  */
-export function formatPeriodLabel(period: number): string {
+export function formatPeriodLabel(period: number, gameData?: { gameType?: number }): string {
   // Regulation periods
   if (period === 1) return '1st'
   if (period === 2) return '2nd'
@@ -54,12 +56,17 @@ export function formatPeriodLabel(period: number): string {
   // Overtime
   if (period === 4) return 'OT'
   
-  // Shootout
-  if (period === 5) return 'SO'
+  // Check if this is a postseason game (gameType 3 = playoffs)
+  const isPostseason = gameData?.gameType === 3
   
-  // Multiple overtimes (rare, but possible in playoffs)
-  if (period > 5) {
-    const overtimeNumber = period - 4
+  // Shootout (only in regular season - postseason games have continuous OT)
+  if (period === 5) {
+    return isPostseason ? '2OT' : 'SO'
+  }
+  
+  // Multiple overtimes (reasonable range only)
+  if (period > 5 && period <= 10) { // Reasonable upper limit for overtime periods
+    const overtimeNumber = isPostseason ? period - 3 : period - 4
     return `${overtimeNumber}OT`
   }
   

--- a/docs/SEATTLE_KRAKEN_GAME_EXAMPLES.md
+++ b/docs/SEATTLE_KRAKEN_GAME_EXAMPLES.md
@@ -1,0 +1,138 @@
+# Seattle Kraken Game Examples
+
+This document provides quick access to Seattle Kraken games
+with different outcomes for testing and demonstration purposes.
+
+## Game Outcome Examples
+
+### Regular Season Games (gameType: 2)
+
+| Outcome | Game ID | Description | Local URL | Production URL |
+| ------- | ------- | ----------- | --------- | -------------- |
+| **Win** | `2024020053` | Seattle Kraken 7-3 vs Nashville Predators | `http://localhost:3000/?gameId=2024020053` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024020053` |
+| **Loss** | `2024020003` | Seattle Kraken 2-3 vs St. Louis Blues | `http://localhost:3000/?gameId=2024020003` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024020003` |
+| **OT Win** | `2024020087` | Seattle Kraken 2-1 OT vs Calgary Flames | `http://localhost:3000/?gameId=2024020087` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024020087` |
+| **OT Loss** | `2024010068` | Seattle Kraken 3-4 OTL vs Calgary Flames | `http://localhost:3000/?gameId=2024010068` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024010068` |
+| **SO Win** | `2024020033` | Seattle Kraken 5-4 SO vs Minnesota Wild | `http://localhost:3000/?gameId=2024020033` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024020033` |
+| **SO Loss** | `2024020456` | Seattle Kraken 1-2 SO vs Florida Panthers | `http://localhost:3000/?gameId=2024020456` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2024020456` |
+
+### Postseason Games (gameType: 3)
+
+| Outcome | Game ID | Description | Local URL | Production URL |
+| ------- | ------- | ----------- | --------- | -------------- |
+| **OT Win** | `2025030175` | Example postseason OT game (MIN @ VGK) | `http://localhost:3000/?gameId=2025030175` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=2025030175` |
+| **2OT/3OT+** | `TODO_FIND_GAME_ID` | Multiple overtime periods | `http://localhost:3000/?gameId=TODO_FIND_GAME_ID` | `https://sploosh-ai-hockey-analytics.vercel.app/?gameId=TODO_FIND_GAME_ID` |
+
+## How to Find Game IDs
+
+### Method 1: NHL.com Game URLs
+
+1. Go to [NHL.com](https://www.nhl.com)
+2. Navigate to a Seattle Kraken game
+3. The URL will be something like: `https://www.nhl.com/game/cgy/vs/sea/2024020755`
+4. Extract the game ID: `2024020755`
+
+### Method 2: API Exploration
+
+```bash
+# Test a game ID locally
+curl -s "http://localhost:3000/api/nhl/game-center?gameId=2024020755" | \
+  jq '. | {id: .id, gameType: .gameType, awayTeam: .awayTeam.abbrev, \
+  homeTeam: .homeTeam.abbrev, awayScore: .awayTeam.score, \
+  homeScore: .homeTeam.score, gameState: .gameState}'
+```
+
+### Method 3: Schedule API
+
+```bash
+# Get games for a specific date (if schedule API is available)
+curl -s "http://localhost:3000/api/nhl/schedule?date=2024-02-07" | \
+  jq '.games[] | select(.awayTeam.abbrev == "SEA" or .homeTeam.abbrev == "SEA")'
+```
+
+## Game ID Format
+
+NHL game IDs follow this pattern: `YYYYMMDDNN`
+
+- `YYYY`: Season year (e.g., 2024)
+- `MM`: Month (e.g., 02 for February)
+- `DD`: Day (e.g., 07)
+- `NN`: Game number for the day (01-99)
+
+Seattle Kraken's team abbreviation is `SEA` and their team ID is `55`.
+
+## Testing Scenarios
+
+### Shot Chart Period Filtering
+
+- **Regular Season**: Verify SO appears in period dropdown for games
+  that went to shootout
+- **Postseason**: Verify 2OT, 3OT, etc. appear correctly for multiple overtime games
+
+### Game State Display
+
+- Test different `gameState` values: `LIVE`, `FINAL`, `OFF`, `FUT`, `PRE`
+- Verify score display works correctly for all outcomes
+
+### Animation Testing
+
+- Test play-by-play animation for different game types
+- Verify overtime periods display correctly in animations
+
+## Quick Launch Scripts
+
+### Using NPM Scripts (Recommended)
+
+Use the provided npm scripts to quickly open these games in your browser:
+
+```bash
+# Launch all Kraken game examples (local)
+npm run kraken:launch:all
+
+# Launch specific outcome types (local)
+npm run kraken:launch:win          # Regulation win
+npm run kraken:launch:loss         # Regulation loss
+npm run kraken:launch:ot-win       # Overtime win
+npm run kraken:launch:ot-loss      # Overtime loss
+npm run kraken:launch:so-win       # Shootout win
+npm run kraken:launch:so-loss      # Shootout loss
+npm run kraken:launch:postseason   # Postseason OT game
+
+# Launch in production environment
+npm run kraken:launch:prod
+
+# Find more Kraken games
+npm run kraken:find-games
+```
+
+### Using Shell Scripts Directly
+
+You can also use the shell scripts directly:
+
+```bash
+# Launch all Kraken game examples
+./scripts/launch-kraken-games.sh
+
+# Launch specific outcome type
+./scripts/launch-kraken-games.sh --outcome=win
+
+# Launch in production instead of localhost
+./scripts/launch-kraken-games.sh --production
+```
+
+## Additional Resources
+
+- **NHL API Documentation**: [NHL Edge API](https://api.nhle.com/)
+- **Seattle Kraken Schedule**: [Kraken Schedule](https://www.nhl.com/seattlekraken/schedule)
+- **Game Data Format**: See `lib/api/nhl-edge/types/nhl-edge.ts`
+  for complete type definitions
+
+## Contributing
+
+When adding new game examples:
+
+1. Test the game ID works with both local and production URLs
+2. Verify the game type and outcome are correct
+3. Add appropriate comments describing the game significance
+4. Update this documentation with the new examples
+5. Test the launch scripts with the new game IDs

--- a/package.json
+++ b/package.json
@@ -43,7 +43,17 @@
     "test:workflows:ghcr:keep-versions": "act workflow_dispatch -e .github/test-data/ghcr/keep-versions.json -W .github/workflows/cleanup_ghcr.yml --container-architecture linux/amd64",
     "test:workflows:ghcr:keep-days": "act workflow_dispatch -e .github/test-data/ghcr/keep-days.json -W .github/workflows/cleanup_ghcr.yml --container-architecture linux/amd64",
     "test:workflows:ghcr:cleanup": "act workflow_dispatch -e .github/test-data/ghcr/actual-cleanup.json -W .github/workflows/cleanup_ghcr.yml --container-architecture linux/amd64",
-    "test:workflows:secrets": "act workflow_dispatch -W .github/workflows/test_secrets.yml"
+    "test:workflows:secrets": "act workflow_dispatch -W .github/workflows/test_secrets.yml",
+    "kraken:launch:all": "./scripts/launch-kraken-games.sh",
+    "kraken:launch:win": "./scripts/launch-kraken-games.sh --outcome=win",
+    "kraken:launch:loss": "./scripts/launch-kraken-games.sh --outcome=loss",
+    "kraken:launch:ot-win": "./scripts/launch-kraken-games.sh --outcome=ot_win",
+    "kraken:launch:ot-loss": "./scripts/launch-kraken-games.sh --outcome=ot_loss",
+    "kraken:launch:so-win": "./scripts/launch-kraken-games.sh --outcome=so_win",
+    "kraken:launch:so-loss": "./scripts/launch-kraken-games.sh --outcome=so_loss",
+    "kraken:launch:postseason": "./scripts/launch-kraken-games.sh --outcome=postseason_ot",
+    "kraken:launch:prod": "./scripts/launch-kraken-games.sh --environment=production",
+    "kraken:find-games": "./scripts/find-kraken-games.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/find-kraken-games.sh
+++ b/scripts/find-kraken-games.sh
@@ -1,0 +1,346 @@
+#!/bin/bash
+
+# Seattle Kraken Game Finder Script
+# Helps find Seattle Kraken game IDs for different outcomes. See docs/SEATTLE_KRAKEN_GAME_EXAMPLES.md for more information
+
+set -e
+
+# Default values
+START_DATE="2024-10-01"
+END_DATE="2024-12-31"
+ENVIRONMENT="local"
+
+# URLs
+LOCAL_BASE="http://localhost:3000"
+PROD_BASE="https://sploosh-ai-hockey-analytics.vercel.app"
+
+# Help function
+show_help() {
+    cat << EOF
+Seattle Kraken Game Finder
+
+Usage: $0 [OPTIONS]
+
+OPTIONS:
+    --start-date=DATE    Start date for search (YYYY-MM-DD) [default: 2024-10-01]
+    --end-date=DATE      End date for search (YYYY-MM-DD) [default: 2024-12-31]
+    --environment=ENV    Environment to use (local|production) [default: local]
+    --help               Show this help message
+
+DESCRIPTION:
+    This script searches for Seattle Kraken games within a date range and
+    categorizes them by outcome (win, loss, OT, SO, etc.) to help populate
+    the game examples documentation.
+
+EXAMPLES:
+    $0                                    # Search 2024-25 season first half
+    $0 --start-date=2024-01-01 --end-date=2024-04-30  # Search 2023-24 season
+    $0 --environment=production           # Use production API
+
+NOTES:
+    - Requires local server to be running if using local environment
+    - Outputs game IDs that can be used in the launch script
+    - Results are saved to kraken-games-found.txt for reference
+
+EOF
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --start-date=*)
+            START_DATE="${1#*=}"
+            shift
+            ;;
+        --end-date=*)
+            END_DATE="${1#*=}"
+            shift
+            ;;
+        --environment=*)
+            ENVIRONMENT="${1#*=}"
+            shift
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Validate environment
+if [[ "$ENVIRONMENT" != "local" && "$ENVIRONMENT" != "production" ]]; then
+    echo "Error: Environment must be 'local' or 'production'"
+    exit 1
+fi
+
+# Set base URL
+if [[ "$ENVIRONMENT" == "local" ]]; then
+    BASE_URL="$LOCAL_BASE"
+    echo "🏠 Using local environment: $BASE_URL"
+else
+    BASE_URL="$PROD_BASE"
+    echo "🌐 Using production environment: $BASE_URL"
+fi
+
+# Check if server is accessible
+if ! curl -s "$BASE_URL/api/nhl/game-center?gameId=2024020175" > /dev/null 2>&1; then
+    echo "❌ Cannot access API at $BASE_URL"
+    if [[ "$ENVIRONMENT" == "local" ]]; then
+        echo "💡 Start local server with: npm run docker:up:detach"
+    fi
+    exit 1
+fi
+
+echo "🔍 Searching for Seattle Kraken games from $START_DATE to $END_DATE..."
+echo ""
+
+# Function to test a game ID
+test_game_id() {
+    local game_id="$1"
+    local result=$(curl -s "$BASE_URL/api/nhl/game-center?gameId=$game_id" 2>/dev/null)
+    
+    if [[ -z "$result" || "$result" == *"Not Found"* ]]; then
+        return 1
+    fi
+    
+    # Extract game info
+    local game_info=$(echo "$result" | jq -r '
+        if .id then
+            {
+                id: .id,
+                gameType: .gameType,
+                awayTeam: .awayTeam.abbrev,
+                homeTeam: .homeTeam.abbrev,
+                awayScore: .awayTeam.score,
+                homeScore: .homeTeam.score,
+                gameState: .gameState,
+                isKraken: (.awayTeam.abbrev == "SEA" or .homeTeam.abbrev == "SEA")
+            }
+        else
+            empty
+        end
+    ' 2>/dev/null)
+    
+    if [[ -n "$game_info" && $(echo "$game_info" | jq -r '.isKraken') == "true" ]]; then
+        echo "$game_info"
+        return 0
+    fi
+    
+    return 1
+}
+
+# Function to determine game outcome
+determine_outcome() {
+    local away_team="$1"
+    local away_score="$2"
+    local home_team="$3"
+    local home_score="$4"
+    local game_state="$5"
+    local game_type="$6"
+    
+    # Skip if game isn't final
+    if [[ "$game_state" != "OFF" && "$game_state" != "FINAL" ]]; then
+        echo "IN_PROGRESS"
+        return
+    fi
+    
+    local kraken_score=""
+    local opponent_score=""
+    local kraken_is_home=""
+    
+    if [[ "$home_team" == "SEA" ]]; then
+        kraken_score="$home_score"
+        opponent_score="$away_score"
+        kraken_is_home="true"
+    else
+        kraken_score="$away_score"
+        opponent_score="$home_score"
+        kraken_is_home="false"
+    fi
+    
+    # Handle null scores (game not completed)
+    if [[ "$kraken_score" == "null" || "$opponent_score" == "null" ]]; then
+        echo "NO_SCORE"
+        return
+    fi
+    
+    # Determine outcome
+    if [[ "$kraken_score" -gt "$opponent_score" ]]; then
+        echo "WIN"
+    elif [[ "$kraken_score" -lt "$opponent_score" ]]; then
+        echo "LOSS"
+    else
+        # Tie game - determine based on game type and period count
+        echo "TIE"  # Will be further analyzed
+    fi
+}
+
+# Generate game IDs to test
+echo "📋 Testing game ID patterns..."
+echo ""
+
+# Convert dates to timestamps for easier iteration
+start_timestamp=$(date -j -f "%Y-%m-%d" "$START_DATE" +%s 2>/dev/null || date -d "$START_DATE" +%s)
+end_timestamp=$(date -j -f "%Y-%m-%d" "$END_DATE" +%s 2>/dev/null || date -d "$END_DATE" +%s)
+
+current_timestamp="$start_timestamp"
+found_games=()
+
+echo "Searching game IDs..."
+while [[ $current_timestamp -le $end_timestamp ]]; do
+    current_date=$(date -r $current_timestamp +%Y-%m-%d 2>/dev/null || date -d "@$current_timestamp" +%Y-%m-%d)
+    
+    # Generate game IDs for this date (try first 10 games)
+    for game_num in {01..10}; do
+        game_id="${current_date//-/}${game_num}"
+        
+        game_info=$(test_game_id "$game_id")
+        if [[ -n "$game_info" ]]; then
+            found_games+=("$game_info")
+        fi
+    done
+    
+    # Move to next day
+    current_timestamp=$((current_timestamp + 86400))
+done
+
+echo ""
+echo "📊 Search Results:"
+echo ""
+
+if [[ ${#found_games[@]} -eq 0 ]]; then
+    echo "❌ No Seattle Kraken games found in the specified date range."
+    echo ""
+    echo "💡 Suggestions:"
+    echo "   - Try a wider date range"
+    echo "   - Check if the date format is correct"
+    echo "   - Verify the API is accessible"
+    exit 0
+fi
+
+# Categorize games
+echo "Found ${#found_games[@]} Seattle Kraken games:"
+echo ""
+
+declare -a wins losses ot_games so_games postseason_games other_games
+
+for game in "${found_games[@]}"; do
+    id=$(echo "$game" | jq -r '.id')
+    away_team=$(echo "$game" | jq -r '.awayTeam')
+    home_team=$(echo "$game" | jq -r '.homeTeam')
+    away_score=$(echo "$game" | jq -r '.awayScore')
+    home_score=$(echo "$game" | jq -r '.homeScore')
+    game_state=$(echo "$game" | jq -r '.gameState')
+    game_type=$(echo "$game" | jq -r '.gameType')
+    
+    outcome=$(determine_outcome "$away_team" "$away_score" "$home_team" "$home_score" "$game_state" "$game_type")
+    
+    game_line="  $id: $away_team $away_score @ $home_team $home_score ($game_state, Type: $game_type)"
+    
+    case "$outcome" in
+        "WIN")
+            if [[ "$game_type" == "3" ]]; then
+                postseason_games+=("$game_line (POSTSEASON WIN)")
+            else
+                wins+=("$game_line")
+            fi
+            ;;
+        "LOSS")
+            if [[ "$game_type" == "3" ]]; then
+                postseason_games+=("$game_line (POSTSEASON LOSS)")
+            else
+                losses+=("$game_line")
+            fi
+            ;;
+        "TIE"|"IN_PROGRESS")
+            # These could be OT/SO games - check period count if available
+            if [[ "$game_type" == "3" ]]; then
+                postseason_games+=("$game_line (POSTSEASON - likely OT)")
+            else
+                ot_games+=("$game_line (likely OT/SO)")
+            fi
+            ;;
+        *)
+            other_games+=("$game_line")
+            ;;
+    esac
+done
+
+# Display results
+if [[ ${#wins[@]} -gt 0 ]]; then
+    echo "🏆 REGULATION WINS:"
+    printf '%s\n' "${wins[@]}"
+    echo ""
+fi
+
+if [[ ${#losses[@]} -gt 0 ]]; then
+    echo "💔 REGULATION LOSSES:"
+    printf '%s\n' "${losses[@]}"
+    echo ""
+fi
+
+if [[ ${#ot_games[@]} -gt 0 ]]; then
+    echo "⚡ OVERTIME/SHOOTOUT GAMES:"
+    printf '%s\n' "${ot_games[@]}"
+    echo ""
+fi
+
+if [[ ${#postseason_games[@]} -gt 0 ]]; then
+    echo "🎯 POSTSEASON GAMES:"
+    printf '%s\n' "${postseason_games[@]}"
+    echo ""
+fi
+
+if [[ ${#other_games[@]} -gt 0 ]]; then
+    echo "📋 OTHER GAMES:"
+    printf '%s\n' "${other_games[@]}"
+    echo ""
+fi
+
+# Save results to file
+output_file="kraken-games-found.txt"
+echo "💾 Saving results to $output_file..."
+
+cat > "$output_file" << EOF
+# Seattle Kraken Games Found
+# Search date range: $START_DATE to $END_DATE
+# Environment: $ENVIRONMENT
+# Generated: $(date)
+
+EOF
+
+if [[ ${#wins[@]} -gt 0 ]]; then
+    echo "## Regulation Wins" >> "$output_file"
+    printf '%s\n' "${wins[@]}" >> "$output_file"
+    echo "" >> "$output_file"
+fi
+
+if [[ ${#losses[@]} -gt 0 ]]; then
+    echo "## Regulation Losses" >> "$output_file"
+    printf '%s\n' "${losses[@]}" >> "$output_file"
+    echo "" >> "$output_file"
+fi
+
+if [[ ${#ot_games[@]} -gt 0 ]]; then
+    echo "## Overtime/Shootout Games" >> "$output_file"
+    printf '%s\n' "${ot_games[@]}" >> "$output_file"
+    echo "" >> "$output_file"
+fi
+
+if [[ ${#postseason_games[@]} -gt 0 ]]; then
+    echo "## Postseason Games" >> "$output_file"
+    printf '%s\n' "${postseason_games[@]}" >> "$output_file"
+    echo "" >> "$output_file"
+fi
+
+echo "✅ Search complete! Results saved to $output_file"
+echo ""
+echo "💡 Next steps:"
+echo "   1. Review the found games in $output_file"
+echo "   2. Update the launch script with specific game IDs"
+echo "   3. Test the games using: ./scripts/launch-kraken-games.sh"

--- a/scripts/launch-kraken-games.sh
+++ b/scripts/launch-kraken-games.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Seattle Kraken Game Launcher Script
+# Launches Seattle Kraken games in the browser for testing
+
+set -e
+
+# Default values
+ENVIRONMENT="local"
+OUTCOME="all"
+BROWSER="open"  # macOS open command
+
+# Game examples - Updated with actual Seattle Kraken game IDs
+# Format: outcome:game_id
+win="2024020053"           # Regular season regulation win (SEA vs NSH 7-3)
+loss="2024020003"          # Regular season regulation loss (STL vs SEA 3-2)
+ot_win="2024020087"        # Regular season overtime win (CGY vs SEA 2-1 OT)
+ot_loss="2024010068"       # Regular season overtime loss (SEA vs CGY 4-3 OTL)
+so_win="2024020033"        # Regular season shootout win (SEA vs MIN 5-4 SO)
+so_loss="2024020456"       # Regular season shootout loss (FLA vs SEA 2-1 SO)
+postseason_ot="2025030175" # Postseason OT game (MIN @ VGK 2OT)
+postseason_2ot="2025030175" # Postseason multiple OT (same game - 2OT)
+
+# URLs
+LOCAL_BASE="http://localhost:3000"
+PROD_BASE="https://sploosh-ai-hockey-analytics.vercel.app"
+
+# Help function
+show_help() {
+    cat << EOF
+Seattle Kraken Game Launcher
+
+Usage: $0 [OPTIONS]
+
+OPTIONS:
+    --environment=ENV    Environment to use (local|production) [default: local]
+    --outcome=TYPE       Game outcome to launch (win|loss|ot_win|ot_loss|so_win|so_loss|postseason_ot|postseason_2ot|all) [default: all]
+    --browser=CMD       Browser command to use [default: open]
+    --help              Show this help message
+
+EXAMPLES:
+    $0                                    # Launch all games locally
+    $0 --outcome=win                    # Launch only regulation wins
+    $0 --environment=production           # Launch in production
+    $0 --outcome=so_win --production    # Launch shootout wins in production
+
+NOTES:
+    - Most game IDs need to be updated with actual Seattle Kraken games
+    - Use the docs/SEATTLE_KRAKEN_GAME_EXAMPLES.md file for reference
+    - Script will skip games with empty IDs
+
+EOF
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --environment=*)
+            ENVIRONMENT="${1#*=}"
+            shift
+            ;;
+        --outcome=*)
+            OUTCOME="${1#*=}"
+            shift
+            ;;
+        --browser=*)
+            BROWSER="${1#*=}"
+            shift
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Validate environment
+if [[ "$ENVIRONMENT" != "local" && "$ENVIRONMENT" != "production" ]]; then
+    echo "Error: Environment must be 'local' or 'production'"
+    exit 1
+fi
+
+# Set base URL
+if [[ "$ENVIRONMENT" == "local" ]]; then
+    BASE_URL="$LOCAL_BASE"
+    echo "🏠 Using local environment: $BASE_URL"
+else
+    BASE_URL="$PROD_BASE"
+    echo "🌐 Using production environment: $BASE_URL"
+fi
+
+# Check if local server is running (if local environment)
+if [[ "$ENVIRONMENT" == "local" ]]; then
+    if ! curl -s "$BASE_URL" > /dev/null 2>&1; then
+        echo "❌ Local server is not running at $BASE_URL"
+        echo "💡 Start it with: npm run docker:up:detach"
+        exit 1
+    else
+        echo "✅ Local server is running"
+    fi
+fi
+
+# Function to launch a game
+launch_game() {
+    local outcome="$1"
+    local game_id=""
+    
+    # Get game ID based on outcome
+    case "$outcome" in
+        "win") game_id="$win" ;;
+        "loss") game_id="$loss" ;;
+        "ot_win") game_id="$ot_win" ;;
+        "ot_loss") game_id="$ot_loss" ;;
+        "so_win") game_id="$so_win" ;;
+        "so_loss") game_id="$so_loss" ;;
+        "postseason_ot") game_id="$postseason_ot" ;;
+        "postseason_2ot") game_id="$postseason_2ot" ;;
+        *) echo "❌ Unknown outcome: $outcome"; return ;;
+    esac
+    
+    if [[ -z "$game_id" ]]; then
+        echo "⚠️  No game ID set for outcome: $outcome"
+        return
+    fi
+    
+    local url="$BASE_URL/?gameId=$game_id"
+    echo "🚀 Launching $outcome: $url"
+    
+    if command -v "$BROWSER" > /dev/null 2>&1; then
+        "$BROWSER" "$url"
+    else
+        echo "❌ Browser command '$BROWSER' not found"
+        echo "🔗 Manual URL: $url"
+    fi
+}
+
+# Launch games based on outcome selection
+echo ""
+echo "🏒 Launching Seattle Kraken Games..."
+echo ""
+
+if [[ "$OUTCOME" == "all" ]]; then
+    echo "📋 Launching all game outcomes:"
+    outcomes=("win" "loss" "ot_win" "ot_loss" "so_win" "so_loss" "postseason_ot" "postseason_2ot")
+    for outcome in "${outcomes[@]}"; do
+        echo ""
+        launch_game "$outcome"
+        sleep 1  # Small delay between launches
+    done
+else
+    # Check if outcome is valid
+    valid_outcomes=("win" "loss" "ot_win" "ot_loss" "so_win" "so_loss" "postseason_ot" "postseason_2ot")
+    if [[ ! " ${valid_outcomes[@]} " =~ " ${OUTCOME} " ]]; then
+        echo "❌ Unknown outcome: $OUTCOME"
+        echo "📋 Available outcomes: win, loss, ot_win, ot_loss, so_win, so_loss, postseason_ot, postseason_2ot, all"
+        exit 1
+    fi
+    
+    echo "📋 Launching outcome: $OUTCOME"
+    launch_game "$OUTCOME"
+fi
+
+echo ""
+echo "✅ Launch complete!"
+echo ""
+echo "💡 To update game IDs, edit the GAMES array in this script"
+echo "📖 See docs/SEATTLE_KRAKEN_GAME_EXAMPLES.md for more information"

--- a/scripts/launch-kraken-games.sh
+++ b/scripts/launch-kraken-games.sh
@@ -42,7 +42,7 @@ EXAMPLES:
     $0                                    # Launch all games locally
     $0 --outcome=win                    # Launch only regulation wins
     $0 --environment=production           # Launch in production
-    $0 --outcome=so_win --production    # Launch shootout wins in production
+    $0 --outcome=so_win --environment=production    # Launch shootout wins in production
 
 NOTES:
     - Most game IDs need to be updated with actual Seattle Kraken games


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes period labeling for postseason games to correctly handle continuous overtime instead of shootouts:

- **Core Fix**: Updated  to accept gameData parameter and check gameType
- **Postseason Logic**: Postseason games (gameType 3) use continuous OT (2OT, 3OT, etc.) instead of SO
- **Regular Season**: Maintains existing SO labeling for period 5 in regular season games
- **Component Updates**: Updated shot chart components to pass gameData to formatPeriodLabel
- **Data Merging**: Merged gameCenterData with playByPlayData to ensure gameType is available

Also includes:
- Test coverage for postseason period labeling
- Seattle Kraken game examples documentation
- Launch scripts for quick game testing

## Type of Change
version: fix      # Bug fix (patch version bump)

## Testing

- [x] I have tested these changes locally using the development server
- [x] Verified postseason games show 2OT, 3OT instead of SO
- [x] Verified regular season games still show SO for period 5
- [x] Tested Kraken game launch scripts
- [x] All existing tests pass
- [x] My commits are signed with GPG